### PR TITLE
More declerative router

### DIFF
--- a/ApiConnector.xcodeproj/project.pbxproj
+++ b/ApiConnector.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		CE2FC5BC1E41FB400072662F /* QueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2FC5BB1E41FB400072662F /* QueryTests.swift */; };
 		CE2FC5C01E422DC80072662F /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2FC5BF1E422DC80072662F /* Environment.swift */; };
 		CE3919A11DD21929006D1DFB /* ResponseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3919A01DD21929006D1DFB /* ResponseProvider.swift */; };
+		CE77A90E1E487EAC00CA26CA /* URLRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE77A90D1E487EAC00CA26CA /* URLRoute.swift */; };
 		CE81A35D1E326D9700317922 /* Scheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81A35C1E326D9700317922 /* Scheme.swift */; };
 		CE81A35F1E32753000317922 /* RoutePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81A35E1E32753000317922 /* RoutePath.swift */; };
 		CE81A3611E35FB3E00317922 /* RouterPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81A3601E35FB3E00317922 /* RouterPathTests.swift */; };
@@ -71,6 +72,7 @@
 		CE2FC5BB1E41FB400072662F /* QueryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryTests.swift; sourceTree = "<group>"; };
 		CE2FC5BF1E422DC80072662F /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		CE3919A01DD21929006D1DFB /* ResponseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseProvider.swift; sourceTree = "<group>"; };
+		CE77A90D1E487EAC00CA26CA /* URLRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRoute.swift; sourceTree = "<group>"; };
 		CE81A35C1E326D9700317922 /* Scheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scheme.swift; sourceTree = "<group>"; };
 		CE81A35E1E32753000317922 /* RoutePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutePath.swift; sourceTree = "<group>"; };
 		CE81A3601E35FB3E00317922 /* RouterPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterPathTests.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 			children = (
 				CE2FC5BF1E422DC80072662F /* Environment.swift */,
 				CED9A7CA1DC89089005CE914 /* Router.swift */,
+				CE77A90D1E487EAC00CA26CA /* URLRoute.swift */,
 				CE81A35C1E326D9700317922 /* Scheme.swift */,
 				CE81A35E1E32753000317922 /* RoutePath.swift */,
 				CE2FC5B91E41F6C20072662F /* Query.swift */,
@@ -337,6 +340,7 @@
 				CE81A35D1E326D9700317922 /* Scheme.swift in Sources */,
 				CE2FC5C01E422DC80072662F /* Environment.swift in Sources */,
 				CE2716901DCA336B00571670 /* JSONModelNetworkConnector.swift in Sources */,
+				CE77A90E1E487EAC00CA26CA /* URLRoute.swift in Sources */,
 				CE2EDD161DC8EAEB00D2D7E7 /* TestConnectorResponse.swift in Sources */,
 				CE27167F1DCA105400571670 /* AlamofireExtension.swift in Sources */,
 				CE3919A11DD21929006D1DFB /* ResponseProvider.swift in Sources */,

--- a/ApiConnector.xcodeproj/project.pbxproj
+++ b/ApiConnector.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		CE2FC5C01E422DC80072662F /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2FC5BF1E422DC80072662F /* Environment.swift */; };
 		CE3919A11DD21929006D1DFB /* ResponseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3919A01DD21929006D1DFB /* ResponseProvider.swift */; };
 		CE77A90E1E487EAC00CA26CA /* URLRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE77A90D1E487EAC00CA26CA /* URLRoute.swift */; };
+		CE77A9101E488B4D00CA26CA /* URLRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE77A90F1E488B4D00CA26CA /* URLRouteTests.swift */; };
 		CE81A35D1E326D9700317922 /* Scheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81A35C1E326D9700317922 /* Scheme.swift */; };
 		CE81A35F1E32753000317922 /* RoutePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81A35E1E32753000317922 /* RoutePath.swift */; };
 		CE81A3611E35FB3E00317922 /* RouterPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE81A3601E35FB3E00317922 /* RouterPathTests.swift */; };
@@ -73,6 +74,7 @@
 		CE2FC5BF1E422DC80072662F /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		CE3919A01DD21929006D1DFB /* ResponseProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseProvider.swift; sourceTree = "<group>"; };
 		CE77A90D1E487EAC00CA26CA /* URLRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRoute.swift; sourceTree = "<group>"; };
+		CE77A90F1E488B4D00CA26CA /* URLRouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRouteTests.swift; sourceTree = "<group>"; };
 		CE81A35C1E326D9700317922 /* Scheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scheme.swift; sourceTree = "<group>"; };
 		CE81A35E1E32753000317922 /* RoutePath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoutePath.swift; sourceTree = "<group>"; };
 		CE81A3601E35FB3E00317922 /* RouterPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterPathTests.swift; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 			children = (
 				CED9A7CC1DC8920E005CE914 /* TestData.swift */,
 				CED9A7CE1DC89744005CE914 /* RouterTests.swift */,
+				CE77A90F1E488B4D00CA26CA /* URLRouteTests.swift */,
 				CE81A3601E35FB3E00317922 /* RouterPathTests.swift */,
 				CE2FC5BB1E41FB400072662F /* QueryTests.swift */,
 				CE27167C1DC9FCE300571670 /* ApiConnectionTests.swift */,
@@ -358,6 +361,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE2716811DCA11EB00571670 /* AlamofireDataRequestTests.swift in Sources */,
+				CE77A9101E488B4D00CA26CA /* URLRouteTests.swift in Sources */,
 				CE2EDD1A1DC9E22200D2D7E7 /* TestConnectorResponseTests.swift in Sources */,
 				CE2FC5BC1E41FB400072662F /* QueryTests.swift in Sources */,
 				CE2716921DCA379F00571670 /* JSONModelNetworkConnectorTests.swift in Sources */,

--- a/ApiConnector/NetworkConnector.swift
+++ b/ApiConnector/NetworkConnector.swift
@@ -39,7 +39,7 @@ public extension ApiConnectionType {
         do {
             let requestHeaders = headers ?? defaultHeaders
             let url = endpoint.url(for: environment)
-            var request = try URLRequest(url: url, method: endpoint.method, headers: requestHeaders)
+            var request = try URLRequest(url: url, method: endpoint.route.method, headers: requestHeaders)
             
             request.httpBody = data
             

--- a/ApiConnector/Query.swift
+++ b/ApiConnector/Query.swift
@@ -13,7 +13,7 @@ public protocol QueryItemValue {
 }
 
 public struct Query {
-    private let items: [(name: String, value: QueryItemValue?)]
+    fileprivate let items: [(name: String, value: QueryItemValue?)]
     
     public init(_ items: (name: String, value: QueryItemValue?)...) {
         self.init(items)
@@ -25,6 +25,22 @@ public struct Query {
     
     public var queryItems: [URLQueryItem] {
         return items.map({ URLQueryItem(name: $0.name, value: $0.value?.stringValue) })
+    }
+}
+
+extension Query: Equatable {
+    public static func == (lhs: Query, rhs: Query) -> Bool {
+        let lhs = lhs.items, rhs = rhs.items
+        guard lhs.count == rhs.count else { return false }
+        
+        for i in 0..<lhs.count {
+            let left = lhs[i], right = rhs[i]
+            if left.name != right.name || left.value?.stringValue != right.value?.stringValue {
+                return false
+            }
+        }
+        
+        return true
     }
 }
 

--- a/ApiConnector/RoutePath.swift
+++ b/ApiConnector/RoutePath.swift
@@ -42,6 +42,12 @@ extension RoutePath: RoutePathComponent {
     }
 }
 
+extension RoutePath: Equatable {
+    public static func == (lhs: RoutePath, rhs: RoutePath) -> Bool {
+        return lhs.path.lazy.map({ $0.stringValue }) == rhs.path.lazy.map({ $0.stringValue })
+    }
+}
+
 extension RoutePath: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: RoutePathComponent...) {
         self.init(elements)

--- a/ApiConnector/Router.swift
+++ b/ApiConnector/Router.swift
@@ -66,9 +66,3 @@ public extension ApiRouter {
         return url
     }
 }
-
-public extension ApiRouter where Self: RawRepresentable, Self.RawValue == String {
-    public var path: RoutePath {
-        return .init(rawValue)
-    }
-}

--- a/ApiConnector/Router.swift
+++ b/ApiConnector/Router.swift
@@ -16,8 +16,6 @@ public protocol ApiRouter {
 }
 
 public extension ApiRouter {
-    public var query: Query? { return nil }
-    public var method: HTTPMethod { return .get }
     public var defaultPath: RoutePath { return [] }
     
     public func url(for environment: EnvironmentType) -> URL {

--- a/ApiConnector/Router.swift
+++ b/ApiConnector/Router.swift
@@ -8,34 +8,6 @@
 
 import Alamofire
 
-public struct URLRoute {
-    public let method: HTTPMethod
-    public let path: RoutePath
-    public let query: Query?
-    
-    public init(_ method: HTTPMethod, _ path: RoutePath, _ query: (name: String, value: QueryItemValue?)...) {
-        self.method = method
-        self.path = path
-        self.query = Query(query)
-    }
-    
-    public init(_ method: HTTPMethod, _ path: RoutePath) {
-        self.method = method
-        self.path = path
-        self.query = nil
-    }
-    
-    public init(_ path: RoutePath, _ query: (name: String, value: QueryItemValue?)...) {
-        self.method = .get
-        self.path = path
-        self.query = Query(query)
-    }
-    
-    public init(_ path: RoutePath) {
-        self.init(.get, path)
-    }
-}
-
 public protocol ApiRouter {
     associatedtype EnvironmentType: ApiEnvironment
     

--- a/ApiConnector/URLRoute.swift
+++ b/ApiConnector/URLRoute.swift
@@ -1,0 +1,43 @@
+//
+//  URLRoute.swift
+//  ApiConnector
+//
+//  Created by Oleksii on 06/02/2017.
+//  Copyright © 2017 WeAreReasonablePeople. All rights reserved.
+//
+
+import Alamofire
+
+public struct URLRoute {
+    public let method: HTTPMethod
+    public let path: RoutePath
+    public let query: Query?
+    
+    public init(_ method: HTTPMethod, _ path: RoutePath, _ query: (name: String, value: QueryItemValue?)...) {
+        self.method = method
+        self.path = path
+        self.query = Query(query)
+    }
+    
+    public init(_ method: HTTPMethod, _ path: RoutePath) {
+        self.method = method
+        self.path = path
+        self.query = nil
+    }
+    
+    public init(_ path: RoutePath, _ query: (name: String, value: QueryItemValue?)...) {
+        self.method = .get
+        self.path = path
+        self.query = Query(query)
+    }
+    
+    public init(_ path: RoutePath) {
+        self.init(.get, path)
+    }
+}
+
+extension URLRoute: Equatable {
+    public static func == (lhs: URLRoute, rhs: URLRoute) -> Bool {
+        return lhs.method == rhs.method && lhs.path == rhs.path && lhs.query == rhs.query
+    }
+}

--- a/ApiConnectorTests/ApiConnectionTests.swift
+++ b/ApiConnectorTests/ApiConnectionTests.swift
@@ -31,7 +31,7 @@ class ApiConnectionTests: XCTestCase {
     
     func testRequestCreation() {
         let request = TestApiConnection<SuccessProvider>(environment: .test).requestData(with: TestData.testBodyData, at: .me, headers: nil).request
-        var expectedRequest = try! URLRequest(url: Router.me.url(for: .test), method: Router.me.method, headers: nil)
+        var expectedRequest = try! URLRequest(url: Router.me.url(for: .test), method: Router.me.route.method, headers: nil)
         expectedRequest.httpBody = TestData.testBodyData
         
         XCTAssertEqual(request, expectedRequest)

--- a/ApiConnectorTests/QueryTests.swift
+++ b/ApiConnectorTests/QueryTests.swift
@@ -11,6 +11,13 @@ import ApiConnector
 
 class QueryTests: XCTestCase {
     
+    func testQueryEquatable() {
+        XCTAssertNotEqual(Query(("userId", "123"), ("today", nil)), Query(("userId", "123")))
+        XCTAssertNotEqual(Query(("userId", "123"), ("today", nil)), Query(("userId", "123"), ("tomorrow", nil)))
+        XCTAssertNotEqual(Query(("userId", "123"), ("today", nil)), Query(("userId", "123"), ("today", "24")))
+        XCTAssertEqual(Query(("userId", "123"), ("today", nil)), Query(("userId", "123"), ("today", nil)))
+    }
+    
     func testQueryCreation() {
         let query = Query(("userId", "123"), ("today", nil))
         let items: [URLQueryItem] = [.init(name: "userId", value: "123"), .init(name: "today", value: nil)]

--- a/ApiConnectorTests/RouterPathTests.swift
+++ b/ApiConnectorTests/RouterPathTests.swift
@@ -11,6 +11,11 @@ import ApiConnector
 
 class RouterPathTests: XCTestCase {
     
+    func testRouterPathEquatable() {
+        XCTAssertNotEqual(RoutePath("new", "api", "cards"), RoutePath("new", "api"))
+        XCTAssertEqual(RoutePath("new", "api", "cards"), RoutePath("new", "api", "cards"))
+    }
+    
     func testRouterPathArrayCreation() {
         let path = "/new/api/cards"
         

--- a/ApiConnectorTests/RouterTests.swift
+++ b/ApiConnectorTests/RouterTests.swift
@@ -14,6 +14,7 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(Router.me.url(for: .test).absoluteString, "http://test.com/me")
         XCTAssertEqual(Router.pictures.url(for: .test).absoluteString, "http://test.com/pictures")
         XCTAssertEqual(Router.pictures.url(for: .localhost).absoluteString, "http://localhost:8080/pictures")
+        XCTAssertEqual(Router.posts(userId: "myId").url(for: .test).absoluteString, "http://test.com/posts?userId=myId")
     }
     
     func testRouterMethod() {

--- a/ApiConnectorTests/RouterTests.swift
+++ b/ApiConnectorTests/RouterTests.swift
@@ -18,7 +18,7 @@ class RouterTests: XCTestCase {
     }
     
     func testRouterMethod() {
-        XCTAssertEqual(Router.me.method, .get)
+        XCTAssertEqual(Router.me.route.method, .get)
     }
     
 }

--- a/ApiConnectorTests/TestData.swift
+++ b/ApiConnectorTests/TestData.swift
@@ -21,9 +21,22 @@ enum Environment: ApiEnvironment {
     }
 }
 
-enum Router: String, ApiRouter {
-    typealias EnvironmentType = Environment
+enum Router {
     case me, pictures
+    case posts(userId: String)
+}
+
+extension Router: ApiRouter {
+    typealias EnvironmentType = Environment
+    
+    var route: URLRoute {
+        switch self {
+        case .me: return .init(["me"])
+        case .pictures: return .init(.get, ["pictures"])
+        case let .posts(userId: userId):
+            return .init(["posts"], ("userId", userId))
+        }
+    }
 }
 
 struct TestData {

--- a/ApiConnectorTests/URLRouteTests.swift
+++ b/ApiConnectorTests/URLRouteTests.swift
@@ -1,0 +1,18 @@
+//
+//  URLRouteTests.swift
+//  ApiConnector
+//
+//  Created by Oleksii on 06/02/2017.
+//  Copyright © 2017 WeAreReasonablePeople. All rights reserved.
+//
+
+import XCTest
+import ApiConnector
+
+class URLRouteTests: XCTestCase {
+    
+    func testUrlRouteEquatable() {
+        XCTAssertEqual(URLRoute(["myPath"], ("user", nil)), URLRoute(.get, ["myPath"], ("user", nil)))
+    }
+    
+}

--- a/README.md
+++ b/README.md
@@ -34,33 +34,20 @@ enum Environment: ApiEnvironment {
     }
 }
 
-enum Router: ApiRouter {
-    typealias EnvironmentType = Environment
-    
+enum Router {
     case auth, me
     case posts(for: Date)
-    
-    var path: RoutePath {
-        switch self {
-        case .auth: return ["auth"]
-        case .me: return ["me"]
-        case .posts(_): return ["posts"]
-        }
-    }
-    
-    var query: Query? {
-        switch self {
-        case let .posts(for: date):
-            return Query(("date", date.convertToString), ("userId": "someId"))
-        default:
-            return nil
-        }
-    }
+}
 
-    var method: HTTPMethod {
+extension Router: ApiRouter {
+    typealias EnvironmentType = Environment
+    
+    var route: URLRoute {
         switch self {
-        case .auth: return .post
-        default: return .get
+        case .me: return .init(["me"])
+        case .auth: return .init(.post, ["auth"])
+        case let .posts(for: date):
+            return .init(["posts"], ("date", date), ("userId", "someId"))
         }
     }
 }
@@ -70,7 +57,7 @@ And then we can get the url for specific `endpoint` like this:
 
 ```swift
 let url = Router.me.url(for: .test)
-print(url.absoluteString) //prints http://mytestserver.com:80/me
+print(url.absoluteString) //prints http://mytestserver.com/me
 ```
 
 ##API Connection


### PR DESCRIPTION
This PR makes the following code:

```swift
enum Router: ApiRouter {
    typealias EnvironmentType = Environment

    case auth, me
    case posts(for: Date)

    var path: RoutePath {
        switch self {
        case .auth: return ["auth"]
        case .me: return ["me"]
        case .posts(_): return ["posts"]
        }
    }

    var query: Query? {
        switch self {
        case let .posts(for: date):
            return Query(("date", date.convertToString), ("userId", "someId"))
        default:
            return nil
        }
    }

    var method: HTTPMethod {
        switch self {
        case .auth: return .post
        default: return .get
        }
    }
}
```

becomes the following:

```swift
enum Router {
    case auth, me
    case posts(for: Date)
}

extension Router: ApiRouter {
    typealias EnvironmentType = Environment
    
    var route: URLRoute {
        switch self {
        case .me: return .init(["me"])
        case .auth: return .init(.post, ["auth"])
        case let .posts(for: date):
            return .init(["posts"], ("date", date), ("userId", "someId"))
        }
    }
}
```