### PR TITLE
Response type

### DIFF
--- a/ApiConnector.xcodeproj/project.pbxproj
+++ b/ApiConnector.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		CED9A7C91DC88E53005CE914 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CED9A7C81DC88E53005CE914 /* Alamofire.framework */; };
 		CED9A7CD1DC8920E005CE914 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED9A7CC1DC8920E005CE914 /* TestData.swift */; };
 		CED9A7D01DC8A1AC005CE914 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CED9A7C81DC88E53005CE914 /* Alamofire.framework */; };
+		CEF42D6C1E89134B00A7FA79 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF42D6B1E89134B00A7FA79 /* Response.swift */; };
+		CEF42D6E1E89164800A7FA79 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF42D6D1E89164800A7FA79 /* ResponseTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +70,8 @@
 		CED9A7BB1DC88D89005CE914 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CED9A7C81DC88E53005CE914 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		CED9A7CC1DC8920E005CE914 /* TestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
+		CEF42D6B1E89134B00A7FA79 /* Response.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		CEF42D6D1E89164800A7FA79 /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +108,7 @@
 			children = (
 				CE2EDCE91DC8C75A00D2D7E7 /* NetworkConnector.swift */,
 				CE27168F1DCA336B00571670 /* JSONModelNetworkConnector.swift */,
+				CEF42D6B1E89134B00A7FA79 /* Response.swift */,
 			);
 			name = NetworkConnector;
 			sourceTree = "<group>";
@@ -175,6 +180,7 @@
 				CE2716911DCA379F00571670 /* JSONModelNetworkConnectorTests.swift */,
 				CE2EDD121DC8E55700D2D7E7 /* TestConnectorTests.swift */,
 				CE2EDD191DC9E22200D2D7E7 /* TestConnectorResponseTests.swift */,
+				CEF42D6D1E89164800A7FA79 /* ResponseTests.swift */,
 				CED9A7BB1DC88D89005CE914 /* Info.plist */,
 			);
 			path = ApiConnectorTests;
@@ -305,6 +311,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CEF42D6C1E89134B00A7FA79 /* Response.swift in Sources */,
 				CE2716901DCA336B00571670 /* JSONModelNetworkConnector.swift in Sources */,
 				7B320F1C1E85768A00E218A9 /* URLSessionDataTaskExtension.swift in Sources */,
 				CE2EDD161DC8EAEB00D2D7E7 /* TestConnectorResponse.swift in Sources */,
@@ -322,6 +329,7 @@
 				CE2EDD1A1DC9E22200D2D7E7 /* TestConnectorResponseTests.swift in Sources */,
 				CE2716921DCA379F00571670 /* JSONModelNetworkConnectorTests.swift in Sources */,
 				CED9A7CD1DC8920E005CE914 /* TestData.swift in Sources */,
+				CEF42D6E1E89164800A7FA79 /* ResponseTests.swift in Sources */,
 				CE27167D1DC9FCE300571670 /* ApiConnectionTests.swift in Sources */,
 				CE2EDD131DC8E55700D2D7E7 /* TestConnectorTests.swift in Sources */,
 				CE2716871DCA238E00571670 /* RxNetworkConnectorTests.swift in Sources */,

--- a/ApiConnector/Response.swift
+++ b/ApiConnector/Response.swift
@@ -1,0 +1,45 @@
+//
+//  Response.swift
+//  ApiConnector
+//
+//  Created by Oleksii on 27/03/2017.
+//  Copyright © 2017 WeAreReasonablePeople. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+public struct Response {
+    public let request: URLRequest
+    public let response: HTTPURLResponse
+    public let data: Data
+    
+    public init(for request: URLRequest, response: HTTPURLResponse, data: Data) {
+        self.request = request
+        self.response = response
+        self.data = data
+    }
+    
+    public init(for request: URLRequest, with code: Int, data: Data) {
+        let response = HTTPURLResponse(url: request.url!, statusCode: code, httpVersion: nil, headerFields: nil)!
+        self.init(for: request, response: response, data: data)
+    }
+    
+    public func validate(_ validation: DataRequest.Validation) throws -> Response {
+        switch validation(request, response, data) {
+        case .success: return self
+        case let .failure(error): throw error
+        }
+    }
+    
+    public static let defaultValidation: DataRequest.Validation = { request, response, data -> Request.ValidationResult in
+        let code = response.statusCode
+        switch code {
+        case 200...299:
+            return .success
+        default:
+            let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: code))
+            return .failure(error)
+        }
+    }
+}

--- a/ApiConnector/Response.swift
+++ b/ApiConnector/Response.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftyJSONModel
 import Alamofire
 
 public struct Response {
@@ -23,6 +24,10 @@ public struct Response {
     public init(for request: URLRequest, with code: Int, data: Data) {
         let response = HTTPURLResponse(url: request.url!, statusCode: code, httpVersion: nil, headerFields: nil)!
         self.init(for: request, response: response, data: data)
+    }
+    
+    public init(for request: URLRequest, with code: Int, jsonObject: JSONRepresentable) throws {
+        self.init(for: request, with: code, data: try jsonObject.jsonValue.rawData())
     }
     
     public func validate(_ validation: DataRequest.Validation) throws -> Response {

--- a/ApiConnector/TestConnector.swift
+++ b/ApiConnector/TestConnector.swift
@@ -15,21 +15,8 @@ public final class TestConnector<T: ResponseProvider>: DataRequestType {
             .just()
             .observeOn(SerialDispatchQueueScheduler(qos: .userInitiated))
             .flatMap { T.response(for: request) }
-            .map { $0.validate(validation ?? defaultValidation) }
+            .map { $0.validate(validation ?? Response.defaultValidation) }
             .map { try $0.toResponse() }
             .observeOn(MainScheduler.instance)
-    }
-    
-    static var defaultValidation: DataRequest.Validation {
-        return { request, response, data -> Request.ValidationResult in
-            let code = response.statusCode
-            switch code {
-            case 200...299:
-                return .success
-            default:
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: code))
-                return .failure(error)
-            }
-        }
     }
 }

--- a/ApiConnector/URLSessionDataTaskExtension.swift
+++ b/ApiConnector/URLSessionDataTaskExtension.swift
@@ -12,20 +12,8 @@ import RxSwift
 
 extension URLSessionDataTask: DataRequestType {
     public static func requestObservable(with request: URLRequest, _ validation: (DataRequest.Validation)?) -> Observable<DataResponse<Data>> {
-        var defaultValidation: DataRequest.Validation {
-            return { request, response, data -> Request.ValidationResult in
-                let code = response.statusCode
-                switch code {
-                case 200...299:
-                    return .success
-                default:
-                    let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: code))
-                    return .failure(error)
-                }
-            }
-        }
+        let validation = validation ?? Response.defaultValidation
         
-        let validation = validation ?? defaultValidation
         return Observable<DataResponse<Data>>.create({ observer -> Disposable in
             let config = URLSessionConfiguration.default
             let session = URLSession(configuration: config)

--- a/ApiConnectorTests/ResponseTests.swift
+++ b/ApiConnectorTests/ResponseTests.swift
@@ -1,0 +1,27 @@
+//
+//  ResponseTests.swift
+//  ApiConnector
+//
+//  Created by Oleksii on 27/03/2017.
+//  Copyright © 2017 WeAreReasonablePeople. All rights reserved.
+//
+
+import XCTest
+import Alamofire
+import ApiConnector
+
+class ResponseTests: XCTestCase {
+    
+    func testResponseValidation() {
+        let data = Data()
+        XCTAssertThrowsError(try Response(for: TestData.request, with: 400, data: data).validate(Response.defaultValidation)) { error in
+            if let error = error as? AFError, case let .responseValidationFailed(reason: reason) = error, case let .unacceptableStatusCode(code: code) = reason {
+                XCTAssertEqual(code, 400)
+            } else {
+                XCTFail()
+            }
+        }
+        XCTAssertNotNil(try? Response(for: TestData.request, with: 200, data: data).validate(Response.defaultValidation))
+    }
+    
+}

--- a/ApiConnectorTests/ResponseTests.swift
+++ b/ApiConnectorTests/ResponseTests.swift
@@ -14,6 +14,7 @@ class ResponseTests: XCTestCase {
     
     func testResponseValidation() {
         let data = Data()
+        XCTAssertNotNil(try? Response(for: TestData.request, with: 200, data: data).validate(Response.defaultValidation))
         XCTAssertThrowsError(try Response(for: TestData.request, with: 400, data: data).validate(Response.defaultValidation)) { error in
             if let error = error as? AFError, case let .responseValidationFailed(reason: reason) = error, case let .unacceptableStatusCode(code: code) = reason {
                 XCTAssertEqual(code, 400)
@@ -21,7 +22,13 @@ class ResponseTests: XCTestCase {
                 XCTFail()
             }
         }
-        XCTAssertNotNil(try? Response(for: TestData.request, with: 200, data: data).validate(Response.defaultValidation))
+    }
+    
+    func testReponseJSONInitializable() {
+        let json = TestData.defaultPost.jsonValue
+        let response = try! Response(for: TestData.request, with: 200, jsonObject: json)
+        
+        XCTAssertEqual(response.data, try? json.rawData())
     }
     
 }


### PR DESCRIPTION
This PR starts #44 and will be continued by another one. This one introduces new type: `Response` that will eventually replace `TestConnectorResponse` and `DataResponse<Data>`